### PR TITLE
refactored shape and brush tools

### DIFF
--- a/src/main/java/com/onionshop/entities/Brush.java
+++ b/src/main/java/com/onionshop/entities/Brush.java
@@ -100,7 +100,8 @@ public abstract class Brush implements Tool {
 
         for (int offset = 0; offset < pixelsEffectedByBrush.length; offset++) {
             //Check if the pixels are in the canvas
-            if (x + pixelsEffectedByBrush[offset][0] > 0 && x + pixelsEffectedByBrush[offset][0] < currentCanvas.width
+            if (x + pixelsEffectedByBrush[offset][0] > 0
+                    && x + pixelsEffectedByBrush[offset][0] < currentCanvas.width
                     && y + pixelsEffectedByBrush[offset][1] > 0 &&
                     y + pixelsEffectedByBrush[offset][1] < currentCanvas.height) {
                 //If they are, update the updated pixels list and the canvas itself

--- a/src/main/java/com/onionshop/entities/Circle.java
+++ b/src/main/java/com/onionshop/entities/Circle.java
@@ -16,14 +16,7 @@ public class Circle extends Shape implements Tool {
      * the boundary of the circle.
      */
     public void calculateEffectedPixels() {
-        if (drawStage == 0) {
-            pixelsEffectedByShape = new int[0][0];
-
-            // is incremented to enter stage 1 where we await for user's first input
-            drawStage ++;
-
-            // Initiated when the user makes the second click on the canvas
-        } else if (drawStage == 3) {
+        if (drawStage == 3) {
 
             //Get the width of the clicked positions
             int width = Math.abs(startingCoordinate[0] - endingCoordinate[0]);
@@ -55,6 +48,9 @@ public class Circle extends Shape implements Tool {
                 counter++;
                 plotCounter++;
             }
+        }
+        else {
+            pixelsEffectedByShape = new int[0][0];
         }
     }
 }

--- a/src/main/java/com/onionshop/entities/Line.java
+++ b/src/main/java/com/onionshop/entities/Line.java
@@ -53,13 +53,8 @@ public class Line extends Shape implements Tool {
      *
      * The purpose of calculateEffectedPixels is to calculate and update the variable <pixelsEffectedByShape> by the
      * coordinates of the shape which must be drawn at which drawStage.
-     *
-     * When drawStage = 0,
-     *      As a result of such stage being the default stage where the user have not yet started building the shape,
-     *      we reuse the same calculation as per brush tool's calculateEffectedPixels to possibly draw a square when
-     *      draw() is called.
-     *
-     * When drawStage = 2,
+
+     * When drawStage = 3,
      *      calculateEffectedPixels calculates and updates <pixelsEffectedByShape> by the coordinates of the line. The
      *      calculation is as follows:
      *      1. Calculate the line referring to the x-axis, by incrementing the x coordinate by 1 each time and evaluate
@@ -71,15 +66,7 @@ public class Line extends Shape implements Tool {
      * occur.
      */
     public void calculateEffectedPixels() {
-        // Provide the coordinates of a dot to be drawn by draw() if the drawStage is 0
-        if (drawStage == 0) {
-            pixelsEffectedByShape = new int[0][0];
-
-            // is incremented to enter stage 1 where we await for user's first input
-            drawStage ++;
-
-        // Initiated when the user makes the second click on the canvas
-        } else if (drawStage == 3) {
+        if (drawStage == 3) {
 
             // import the start and end coordinate distances
             int[] distances = calculateStartEndDistance();
@@ -120,6 +107,9 @@ public class Line extends Shape implements Tool {
                 }
 
             }
+        }
+        else {
+            pixelsEffectedByShape = new int[0][0];
         }
     }
 }

--- a/src/main/java/com/onionshop/entities/Rectangle.java
+++ b/src/main/java/com/onionshop/entities/Rectangle.java
@@ -16,14 +16,7 @@ public class Rectangle extends Shape implements Tool {
      * the rectangle.
      */
     public void calculateEffectedPixels() {
-        if (drawStage == 0) {
-            pixelsEffectedByShape = new int[0][0];
-
-            // is incremented to enter stage 1 where we await for user's first input
-            drawStage ++;
-
-            // Initiated when the user makes the second click on the canvas
-        } else if (drawStage == 3) {
+        if (drawStage == 3) {
 
             //Get the width and height of the rectangle
             int width = Math.abs(startingCoordinate[0] - endingCoordinate[0]);
@@ -45,6 +38,9 @@ public class Rectangle extends Shape implements Tool {
             }
 
 
+        }
+        else {
+            pixelsEffectedByShape = new int[0][0];
         }
     }
 

--- a/src/main/java/com/onionshop/entities/Shape.java
+++ b/src/main/java/com/onionshop/entities/Shape.java
@@ -19,16 +19,17 @@ public abstract class Shape implements Tool {
      *                          currently active
      *
      * === drawStage and each stages' purpose ===
-     * When drawStage = 0
-     *      This is the initial stage prior to the user drawing anything on the canvas
-     *
+
      * When drawStage = 1
-     *      This is the stage where the user have drawn the first dot, the canvas should display the starting point
-     *      accordingly
+     *      This is the stage where the user presses their mouse down for the start stage. The start coordinate is
+     *      recorded but nothing is displayed yet
      *
      * When drawStage = 2
-     *      This is the stage where the user have clicked on the canvas a second time, the canvas should display the
-     *      actual shape by calculation
+     *      This is the stage where the canvas is waiting for the user to release their mouse. Nothing is displayed yet
+     *
+     * When drawStage = 3
+     *      This is the stage when the user releases their mouse. At this point, the end coordinate is recorded and the
+     *      shape is calculated and displayed based on where the user released their mouse
      */
 
     protected int[][] pixelsEffectedByShape;
@@ -39,7 +40,7 @@ public abstract class Shape implements Tool {
 
     public Shape(int brushSize) {
         this.lineThickness = 1;
-        this.drawStage = 0;
+        this.drawStage = 1;
         this.startingCoordinate = new int[2];
         this.endingCoordinate = new int[2];
     }
@@ -115,23 +116,9 @@ public abstract class Shape implements Tool {
         // Be sent back up to javafx to be rendered on the canvas.
         int[][] pixelsToUpdate = new int[pixelsEffectedByShape.length][2];
 
-        // Initiated when the user first clicked on the canvas
+        // Initiated when the user first clicks on the canvas
         if (drawStage == 1) {
-            // draws the pixelsEffectedByShape which per the calculation of <calculateEffectedPixels> specific for each
-            // shape, is going to be a square on the first drawStage
-            for (int offset = 0; offset < pixelsEffectedByShape.length; offset++) {
-                //Check if the pixels are in the canvas, we have the
-                if (x + pixelsEffectedByShape[offset][0] > 0
-                        && x + pixelsEffectedByShape[offset][0] < currentCanvas.width
-                        && y + pixelsEffectedByShape[offset][1] > 0
-                        && y + pixelsEffectedByShape[offset][1] < currentCanvas.height) {
-                    //If they are, update the updated pixels list and the canvas itself
-                    pixelsToUpdate[offset][0] = x + pixelsEffectedByShape[offset][0];
-                    pixelsToUpdate[offset][1] = y + pixelsEffectedByShape[offset][1];
-                    currentCanvas.drawingCanvas[x + pixelsEffectedByShape[offset][0]]
-                            [y + pixelsEffectedByShape[offset][1]].setRGB(currentColour.getRGB());
-                }
-            }
+            pixelsToUpdate = new int[0][0];
 
             // increment the drawStage by 1 since we have completed updating method pixelsToUpdate to draw out a dot
             drawStage++;
@@ -140,7 +127,6 @@ public abstract class Shape implements Tool {
             this.startingCoordinate[0] = x;
             this.startingCoordinate[1] = y;
 
-        // Initiated when the user makes the second click on the canvas
         }
         else if (drawStage == 2) {
             //This draw stage returns an empty array while waiting for the user to release their mouse
@@ -148,6 +134,7 @@ public abstract class Shape implements Tool {
             pixelsToUpdate = new int[0][0];
         }
         else if (drawStage == 3) {
+            //This stage is triggered when the user releases their mouse
 
             // store the current (x, y) coordinate into the array of endingCoordinate
             this.endingCoordinate[0] = x;
@@ -158,33 +145,48 @@ public abstract class Shape implements Tool {
             this.calculateEffectedPixels();
 
             pixelsToUpdate = new int[pixelsEffectedByShape.length][2];
+
             // variable <pixel> is getting the exact amount of pixels we have to plot in the pixelsEffectedByShape
             // array
-            for (int pixel = 0; pixel < pixelsEffectedByShape.length; pixel++) {
-                // Check if the pixels are in the canvas, the calculation done in calculateEffectedPixels already
-                // computed the exact coordinates
-                if (pixelsEffectedByShape[pixel][0] > 0  // x > 0
-                        && pixelsEffectedByShape[pixel][0] < currentCanvas.width  // x < width of canvas
-                        && pixelsEffectedByShape[pixel][1] > 0  // y > 0
-                        && pixelsEffectedByShape[pixel][1] < currentCanvas.height) {  // y < width of canvas
+            updatePixelsOnCanvas(currentCanvas, currentColour, pixelsToUpdate, pixelsEffectedByShape);
 
-                    //If they are, update the updated pixels list and the canvas itself
-                    pixelsToUpdate[pixel][0] = pixelsEffectedByShape[pixel][0];
-                    pixelsToUpdate[pixel][1] = pixelsEffectedByShape[pixel][1];
-                    currentCanvas.drawingCanvas[pixelsEffectedByShape[pixel][0]]
-                            [pixelsEffectedByShape[pixel][1]].setRGB(currentColour.getRGB());
-                }
-
-            }
-
-            // reset the drawStage to 0 as we have completed updating method pixelsToUpdate to draw out the shape, the
+            // reset the drawStage to 1 as we have completed updating method pixelsToUpdate to draw out the shape, the
             // user can now redo the entire process over again
-            drawStage = 0;
-            // initiate the calculateEffectedPixels for stage 1 of dot drawing
-            this.calculateEffectedPixels();
+            drawStage = 1;
         }
         // return the array of coordinates as desired which will be drawn by javaFx onto the canvas
         return pixelsToUpdate;
+    }
+
+    /**
+     * This function takes in the list of pixels to be updated based on where the user clicked and
+     * released and then updates those pixels on the backend canvas, while also modifying the list of
+     * pixels that will be sent to the frontend canvas to update for the user.
+     *
+     * @param currentCanvas The current project the user is drawing on
+     * @param currentColour The current colour the user is using
+     * @param pixelsToUpdate The list of pixels that are modified on the backend (will not include pixels outside the
+     *                       canvas
+     * @param pixelsEffectedByShape The calculated list of pixels that should be modified based on where the user
+     *                              released their mouse (may include pixels that are outside the canvas)
+     */
+    private void updatePixelsOnCanvas(Project currentCanvas, Colour currentColour,
+                                        int[][] pixelsToUpdate, int[][] pixelsEffectedByShape) {
+        for (int pixel = 0; pixel < pixelsEffectedByShape.length; pixel++) {
+            // Check if the pixels are in the canvas, the calculation done in calculateEffectedPixels already
+            // computed the exact coordinates
+            if (pixelsEffectedByShape[pixel][0] > 0  // x > 0
+                    && pixelsEffectedByShape[pixel][0] < currentCanvas.width  // x < width of canvas
+                    && pixelsEffectedByShape[pixel][1] > 0  // y > 0
+                    && pixelsEffectedByShape[pixel][1] < currentCanvas.height) {  // y < width of canvas
+
+                //If they are, update the updated pixels list and the canvas itself
+                pixelsToUpdate[pixel][0] = pixelsEffectedByShape[pixel][0];
+                pixelsToUpdate[pixel][1] = pixelsEffectedByShape[pixel][1];
+                currentCanvas.drawingCanvas[pixelsEffectedByShape[pixel][0]]
+                        [pixelsEffectedByShape[pixel][1]].setRGB(currentColour.getRGB());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Refactored the shape tool to remove drawing stages we were no longer using.  Removed the duplicate code between brush and shape, although there is still some similar code (in the updatePixelsOnCanvas function in Shape and draw function in Brush) that updates the backend canvas between brush and shape. The only way to fix it would be to put the implementation of it in a static method in the tool interface which feels a bit awkward. The code doesn't give a duplicate code warning in intellij any more since the implementations are slightly different.

Also i still feel like the code is a bit messy in places especially in the shape tools but also don't want to try rewriting the entire tool right before the deadline so I'm just leaving it, lmk if anyone wants additional changes though.